### PR TITLE
Add syntax highlighting

### DIFF
--- a/packages/react-dev-utils/ansiHTML.js
+++ b/packages/react-dev-utils/ansiHTML.js
@@ -1,0 +1,37 @@
+var ansiHTML = require('ansi-html');
+// Color scheme inspired by https://chriskempson.github.io/base16/css/base16-github.css
+var base00 = 'ffffff'; // Default Background
+var base01 = 'f5f5f5'; // Lighter Background (Used for status bars)
+var base02 = 'c8c8fa'; // Selection Background
+var base03 = '969896'; // Comments, Invisibles, Line Highlighting
+var base04 = 'e8e8e8'; // Dark Foreground (Used for status bars)
+var base05 = '333333'; // Default Foreground, Caret, Delimiters, Operators
+var base06 = 'ffffff'; // Light Foreground (Not often used)
+var base07 = 'ffffff'; // Light Background (Not often used)
+var base08 = 'ed6a43'; // Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
+var base09 = '0086b3'; // Integers, Boolean, Constants, XML Attributes, Markup Link Url
+var base0A = '795da3'; // Classes, Markup Bold, Search Text Background
+var base0B = '183691'; // Strings, Inherited Class, Markup Code, Diff Inserted
+var base0C = '183691'; // Support, Regular Expressions, Escape Characters, Markup Quotes
+var base0D = '795da3'; // Functions, Methods, Attribute IDs, Headings
+var base0E = 'a71d5d'; // Keywords, Storage, Selector, Markup Italic, Diff Changed
+var base0F = '333333'; // Deprecated, Opening/Closing Embedded Language Tags e.g. <?php ?>
+
+// Map ANSI colors from what babel-code-frame uses to base16-github
+// See: https://github.com/babel/babel/blob/e86f62b304d280d0bab52c38d61842b853848ba6/packages/babel-code-frame/src/index.js#L9-L22
+var colors = {
+  reset: [base05, 'transparent'],
+  black: base05,
+  red: base08, /* marker, bg-invalid */
+  green: base0B, /* string */
+  yellow: base08, /* capitalized, jsx_tag, punctuator */
+  blue: base0C,
+  magenta: base0C, /* regex */
+  cyan: base0E, /* keyword */
+  gray: base03, /* comment, gutter */
+  lightgrey: base01,
+  darkgrey: base03
+};
+ansiHTML.setColors(colors);
+
+module.exports = ansiHTML;

--- a/packages/react-dev-utils/failFast.js
+++ b/packages/react-dev-utils/failFast.js
@@ -151,13 +151,12 @@
     // Revisit Jan 2016
     // https://developer.mozilla.org/en-US/Firefox/Releases/51#JavaScript
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1101653
-    let index = 0
     let omittedFramesCount = 0
     for (let frame of resolvedFrames) {
       const {
         functionName,
         fileName, lineNumber, columnNumber,
-        scriptLines,
+        _scriptLines,
         sourceFileName, sourceLineNumber, sourceColumnNumber,
         sourceLines
       } = frame
@@ -221,8 +220,6 @@
       }
 
       trace.appendChild(elem)
-
-      ++index
     }
     container.appendChild(trace)
 

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "ansi-html": "0.0.5",
+    "babel-code-frame": "^6.16.0",
     "chalk": "1.1.3",
     "escape-string-regexp": "1.0.5",
     "html-entities": "1.2.0",

--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -16,28 +16,13 @@
 // that looks similar to our console output. The error overlay is inspired by:
 // https://github.com/glenjamin/webpack-hot-middleware
 
-var ansiHTML = require('ansi-html');
 var SockJS = require('sockjs-client');
 var stripAnsi = require('strip-ansi');
 var url = require('url');
 var formatWebpackMessages = require('./formatWebpackMessages');
 var Entities = require('html-entities').AllHtmlEntities;
+var ansiHTML = require('./ansiHTML');
 var entities = new Entities();
-
-// Color scheme inspired by https://github.com/glenjamin/webpack-hot-middleware
-var colors = {
-  reset: ['transparent', 'transparent'],
-  black: '181818',
-  red: 'E36049',
-  green: 'B3CB74',
-  yellow: 'FFD080',
-  blue: '7CAFC2',
-  magenta: '7FACCA',
-  cyan: 'C3C2EF',
-  lightgrey: 'EBE7E3',
-  darkgrey: '6D7891'
-};
-ansiHTML.setColors(colors);
 
 function createOverlayIframe(onIframeLoad) {
   var iframe = document.createElement('iframe');
@@ -67,8 +52,8 @@ function addOverlayDivTo(iframe) {
   div.style.bottom = 0;
   div.style.width = '100vw';
   div.style.height = '100vh';
-  div.style.backgroundColor = 'black';
-  div.style.color = '#E8E8E8';
+  div.style.backgroundColor = '#fff';
+  div.style.color = '#333';
   div.style.fontFamily = 'Menlo, Consolas, monospace';
   div.style.fontSize = 'large';
   div.style.padding = '2rem';
@@ -116,9 +101,7 @@ function showErrorOverlay(message) {
   ensureOverlayDivExists(function onOverlayDivReady(overlayDiv) {
     // Make it look similar to our terminal.
     overlayDiv.innerHTML =
-      '<span style="color: #' +
-      colors.red +
-      '">Failed to compile.</span><br><br>' +
+      '<span style="color: #E36049">Failed to compile.</span><br><br>' +
       ansiHTML(entities.encode(message));
   });
 }

--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -106,7 +106,7 @@ function showErrorOverlay(message) {
   });
 }
 
-function destroyErrorOverlay() {  
+function destroyErrorOverlay() {
   if (!overlayDiv) {
     // It is not there in the first place.
     return;

--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -27,6 +27,8 @@ function getClientEnvironment(publicUrl) {
       'NODE_ENV': JSON.stringify(
         process.env.NODE_ENV || 'development'
       ),
+      // Allows the chalk library to work on the browser
+      'FORCE_COLOR': JSON.stringify(true),
       // Useful for resolving the correct path to static assets in `public`.
       // For example, <img src={process.env.PUBLIC_URL + '/img/logo.png'} />.
       // This should only be used as an escape hatch. Normally you would put


### PR DESCRIPTION
This PR relies on webpack to be able to pull in CSS from a module like this. Let me know if you're okay with this method.

<img width="884" alt="screen shot 2016-11-29 at 1 49 08 pm" src="https://cloud.githubusercontent.com/assets/212829/20730398/cbdf0aa8-b63a-11e6-95fa-fe06226a6c9c.png">

